### PR TITLE
feat: add recipe images model

### DIFF
--- a/client/src/enums/dietary-restriction.enum.ts
+++ b/client/src/enums/dietary-restriction.enum.ts
@@ -1,0 +1,44 @@
+/**
+ * Represents the dietary restriction of a recipe.
+ */
+export enum DietaryRestriction {
+  /**
+   * Vegan.
+   */
+  Vegan,
+
+  /**
+   * Vegetarian.
+   */
+  Vegetarian,
+
+  /**
+   * Pescatarian.
+   */
+  Pescatarian,
+
+  /**
+   * Gluten-free.
+   */
+  GlutenFree,
+
+  /**
+   * Dairy-free.
+   */
+  DairyFree,
+
+  /**
+   * Nut-free.
+   */
+  NutFree,
+
+  /**
+   * Kosher.
+   */
+  Kosher,
+
+  /**
+   * Halal.
+   */
+  Halal,
+}

--- a/client/src/enums/index.ts
+++ b/client/src/enums/index.ts
@@ -1,0 +1,2 @@
+export * from './recipe-category.enum';
+export * from './dietary-restriction.enum';

--- a/client/src/enums/recipe-category.enum.ts
+++ b/client/src/enums/recipe-category.enum.ts
@@ -1,0 +1,64 @@
+/**
+ * Represents the category of a recipe.
+ */
+export enum RecipeCategory {
+  /**
+   * Appetizer.
+   */
+  Appetizer,
+
+  /**
+   * Main course.
+   */
+  MainCourse,
+
+  /**
+   * Dessert.
+   */
+  Dessert,
+
+  /**
+   * Beverage.
+   */
+  Beverage,
+
+  /**
+   * Salad.
+   */
+  Salad,
+
+  /**
+   * Soup.
+   */
+  Soup,
+
+  /**
+   * Side dish.
+   */
+  SideDish,
+
+  /**
+   * Snack.
+   */
+  Breakfast,
+
+  /**
+   * Brunch.
+   */
+  Brunch,
+
+  /**
+   * Lunch.
+   */
+  Lunch,
+
+  /**
+   * Dinner.
+   */
+  Dinner,
+
+  /**
+   * Snack.
+   */
+  Snack,
+}

--- a/client/src/interfaces/recipe.interface.ts
+++ b/client/src/interfaces/recipe.interface.ts
@@ -1,3 +1,5 @@
+import { DietaryRestriction, RecipeCategory } from "@enums";
+
 /**
  * Represents a recipe.
  */
@@ -16,10 +18,8 @@ export interface Recipe {
   dateCreated: Date;
   /** The date the recipe was last updated. */
   dateUpdated: Date;
-  /** The image URL of the recipe. */
-  image?: string;
-  /** The categories of the recipe (comma-separated). */
-  categories?: string;
+  /** The image IDs of the recipe. */
+  imageIds: number[];
   /** The cook time of the recipe. */
   cookTime?: string;
   /** The prep time of the recipe. */
@@ -32,6 +32,8 @@ export interface Recipe {
   servings?: string;
   /** The calories of the recipe. */
   calories?: number;
-  /** The dietary restrictions of the recipe (comma-separated). */
-  dietaryRestrictions?: string;
+  /** The categories of the recipe. */
+  categories: RecipeCategory[];
+  /** The dietary restrictions of the recipe. */
+  dietaryRestrictions?: DietaryRestriction[];
 }

--- a/client/src/shared/recipe-details/recipe-details.component.html
+++ b/client/src/shared/recipe-details/recipe-details.component.html
@@ -35,8 +35,8 @@
   <br />
 
   <div class="recipe-attribute">
-    <div class="attribute-label"><strong>Image:</strong></div>
-    <div class="attribute-value">{{ recipe.image }}</div>
+    <div class="attribute-label"><strong>Image IDs:</strong></div>
+    <div class="attribute-value">{{ recipe.imageIds }}</div>
   </div>
   <br />
 

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -18,7 +18,8 @@
     "lib": ["es2018", "dom"],
     "paths": {
       "@services": ["src/services"],
-      "@interfaces": ["src/interfaces"]
+      "@interfaces": ["src/interfaces"],
+      "@enums": ["src/enums"]
     },
     "useDefineForClassFields": false
   },

--- a/server/DTOs/RecipeDTO.cs
+++ b/server/DTOs/RecipeDTO.cs
@@ -1,108 +1,93 @@
-﻿using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
+using AutoMapper;
 using server.Enums;
+using server.Models;
 
-namespace server.Models
+namespace server.DTOs
 {
   /// <summary>
   /// A recipe.
   /// </summary>
-  public class Recipe
+  [AutoMap(typeof(Recipe))]
+  public class RecipeDTO
   {
     /// <summary>
     /// The recipe ID.
     /// </summary>
-    [Key]
-    [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
     public required int Id { get; set; }
 
     /// <summary>
     /// The name of the recipe.
     /// </summary>
-    [Column(TypeName = "tinytext")]
     public required string Name { get; set; }
 
     /// <summary>
     /// The description of the recipe.
     /// </summary>
-    [Column(TypeName = "text")]
     public required string Description { get; set; }
 
     /// <summary>
     /// The ingredients of the recipe.
     /// </summary>
-    [Column(TypeName = "text")]
     public required string Ingredients { get; set; }
 
     /// <summary>
     /// The directions of the recipe.
     /// </summary>
-    [Column(TypeName = "text")]
     public required string Directions { get; set; }
 
     /// <summary>
-    /// The images of the recipe.
+    /// The image IDs of the recipe.
     /// </summary>
-    public required IEnumerable<RecipeImage> Images { get; set; }
+    public required IEnumerable<int> ImageIds { get; set; }
 
     /// <summary>
     /// The date the recipe was created.
     /// </summary>
-    [Column(TypeName = "datetime(6)")]
     public required DateTime DateCreated { get; set; }
 
     /// <summary>
     /// The date the recipe was last updated.
     /// </summary>
-    [Column(TypeName = "datetime(6)")]
     public required DateTime DateUpdated { get; set; }
 
     /// <summary>
     /// The cook time of the recipe.
     /// </summary>
-    [Column(TypeName = "tinytext")]
     public string? CookTime { get; set; }
 
     /// <summary>
     /// The prep time of the recipe.
     /// </summary>
-    [Column(TypeName = "tinytext")]
     public string? PrepTime { get; set; }
 
     /// <summary>
     /// The total time of the recipe.
     /// </summary>
-    [Column(TypeName = "tinytext")]
     public string? TotalTime { get; set; }
 
     /// <summary>
     /// The yield of the recipe.
     /// </summary>
-    [Column(TypeName = "tinytext")]
     public string? Yield { get; set; }
 
     /// <summary>
     /// The servings of the recipe.
     /// </summary>
-    [Column(TypeName = "tinytext")]
     public string? Servings { get; set; }
 
     /// <summary>
     /// The calories of the recipe.
     /// </summary>
-    [Column(TypeName = "smallint")]
     public int? Calories { get; set; }
 
     /// <summary>
     /// A list of <see cref="RecipeCategory"/>s for the recipe.
     /// </summary>
-    [Column(TypeName = "text")]
     public required IEnumerable<RecipeCategory> Categories { get; set; }
 
     /// <summary>
     /// A list of <see cref="DietaryRestriction"/>s for the recipe.
     /// </summary>
-    [Column(TypeName = "text")]
     public required IEnumerable<DietaryRestriction> DietaryRestrictions { get; set; }
 }
 }

--- a/server/Data/ApplicationDbContext.cs
+++ b/server/Data/ApplicationDbContext.cs
@@ -1,7 +1,9 @@
 ﻿using Duende.IdentityServer.EntityFramework.Options;
 using Microsoft.AspNetCore.ApiAuthorization.IdentityServer;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.Extensions.Options;
+using server.Enums;
 using server.Models;
 
 namespace server.Data
@@ -9,6 +11,7 @@ namespace server.Data
   public class ApplicationDbContext : ApiAuthorizationDbContext<ApplicationUser>
   {
     public DbSet<Recipe> Recipe { get; set; }
+    public DbSet<RecipeImage> RecipeImage { get; set; }
     public DbSet<Ingredient> Ingredient { get; set; }
 
     public ApplicationDbContext(DbContextOptions options, IOptions<OperationalStoreOptions> operationalStoreOptions)
@@ -18,12 +21,38 @@ namespace server.Data
     {
       base.OnModelCreating(modelBuilder);
 
+      // Recipe constraints
       modelBuilder.Entity<Recipe>().ToTable(table =>
       {
         table.HasCheckConstraint("CK_Recipe_Calories", "Calories >= 0");
         table.HasCheckConstraint("CK_Recipe_DateUpdated", "DateUpdated >= DateCreated");
       });
 
+      // Recipe categories and dietary restrictions
+      modelBuilder.Entity<Recipe>().Property(recipe => recipe.Categories).HasConversion(
+        categories => string.Join(',', categories),
+        categories =>
+          categories.Split(',', StringSplitOptions.RemoveEmptyEntries)
+            .Select(category => Enum.Parse<RecipeCategory>(category))
+            .AsEnumerable(),
+        new ValueComparer<IEnumerable<RecipeCategory>>(
+          (c1, c2) => c1!.SequenceEqual(c2!),
+          c => c.Aggregate(0, (a, v) => HashCode.Combine(a, v.GetHashCode())),
+          c => c.AsEnumerable()
+        ));
+      modelBuilder.Entity<Recipe>().Property(recipe => recipe.DietaryRestrictions).HasConversion(
+        dietaryRestrictions => string.Join(',', dietaryRestrictions),
+        dietaryRestrictions =>
+          dietaryRestrictions.Split(',', StringSplitOptions.RemoveEmptyEntries)
+            .Select(dietaryRestriction => Enum.Parse<DietaryRestriction>(dietaryRestriction))
+            .AsEnumerable(),
+        new ValueComparer<IEnumerable<DietaryRestriction>>(
+          (c1, c2) => c1!.SequenceEqual(c2!),
+          c => c.Aggregate(0, (a, v) => HashCode.Combine(a, v.GetHashCode())),
+          c => c.AsEnumerable()
+        ));
+
+      // Ingredient constraints
       modelBuilder.Entity<Ingredient>().HasIndex(ingredient => ingredient.Name).IsUnique();
     }
   }

--- a/server/Data/Migrations/20231201220813_CreateInitialSchema.Designer.cs
+++ b/server/Data/Migrations/20231201220813_CreateInitialSchema.Designer.cs
@@ -11,7 +11,7 @@ using server.Data;
 namespace server.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    [Migration("20231120174906_CreateInitialSchema")]
+    [Migration("20231201220813_CreateInitialSchema")]
     partial class CreateInitialSchema
     {
         /// <inheritdoc />
@@ -238,12 +238,10 @@ namespace server.Data.Migrations
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserLogin<string>", b =>
                 {
                     b.Property<string>("LoginProvider")
-                        .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("varchar(255)");
 
                     b.Property<string>("ProviderKey")
-                        .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("varchar(255)");
 
                     b.Property<string>("ProviderDisplayName")
                         .HasColumnType("longtext");
@@ -280,12 +278,10 @@ namespace server.Data.Migrations
                         .HasColumnType("varchar(255)");
 
                     b.Property<string>("LoginProvider")
-                        .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("varchar(255)");
 
                     b.Property<string>("Name")
-                        .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("varchar(255)");
 
                     b.Property<string>("Value")
                         .HasColumnType("longtext");
@@ -387,7 +383,8 @@ namespace server.Data.Migrations
                         .HasColumnType("smallint");
 
                     b.Property<string>("Categories")
-                        .HasColumnType("tinytext");
+                        .IsRequired()
+                        .HasColumnType("text");
 
                     b.Property<string>("CookTime")
                         .HasColumnType("tinytext");
@@ -403,13 +400,11 @@ namespace server.Data.Migrations
                         .HasColumnType("text");
 
                     b.Property<string>("DietaryRestrictions")
+                        .IsRequired()
                         .HasColumnType("text");
 
                     b.Property<string>("Directions")
                         .IsRequired()
-                        .HasColumnType("text");
-
-                    b.Property<string>("Image")
                         .HasColumnType("text");
 
                     b.Property<string>("Ingredients")
@@ -440,6 +435,26 @@ namespace server.Data.Migrations
 
                             t.HasCheckConstraint("CK_Recipe_DateUpdated", "DateUpdated >= DateCreated");
                         });
+                });
+
+            modelBuilder.Entity("server.Models.RecipeImage", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("int");
+
+                    b.Property<byte[]>("ImageData")
+                        .IsRequired()
+                        .HasColumnType("mediumblob");
+
+                    b.Property<int>("RecipeId")
+                        .HasColumnType("int");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("RecipeId");
+
+                    b.ToTable("RecipeImage");
                 });
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRoleClaim<string>", b =>
@@ -491,6 +506,22 @@ namespace server.Data.Migrations
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
+                });
+
+            modelBuilder.Entity("server.Models.RecipeImage", b =>
+                {
+                    b.HasOne("server.Models.Recipe", "Recipe")
+                        .WithMany("Images")
+                        .HasForeignKey("RecipeId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Recipe");
+                });
+
+            modelBuilder.Entity("server.Models.Recipe", b =>
+                {
+                    b.Navigation("Images");
                 });
 #pragma warning restore 612, 618
         }

--- a/server/Data/Migrations/20231201220813_CreateInitialSchema.cs
+++ b/server/Data/Migrations/20231201220813_CreateInitialSchema.cs
@@ -140,17 +140,16 @@ namespace server.Data.Migrations
                     Description = table.Column<string>(type: "text", nullable: false),
                     Ingredients = table.Column<string>(type: "text", nullable: false),
                     Directions = table.Column<string>(type: "text", nullable: false),
-                    Image = table.Column<string>(type: "text", nullable: true),
                     DateCreated = table.Column<DateTime>(type: "datetime(6)", nullable: false),
                     DateUpdated = table.Column<DateTime>(type: "datetime(6)", nullable: false),
-                    Categories = table.Column<string>(type: "tinytext", nullable: true),
                     CookTime = table.Column<string>(type: "tinytext", nullable: true),
                     PrepTime = table.Column<string>(type: "tinytext", nullable: true),
                     TotalTime = table.Column<string>(type: "tinytext", nullable: true),
                     Yield = table.Column<string>(type: "tinytext", nullable: true),
                     Servings = table.Column<string>(type: "tinytext", nullable: true),
                     Calories = table.Column<short>(type: "smallint", nullable: true),
-                    DietaryRestrictions = table.Column<string>(type: "text", nullable: true)
+                    Categories = table.Column<string>(type: "text", nullable: false),
+                    DietaryRestrictions = table.Column<string>(type: "text", nullable: false)
                 },
                 constraints: table =>
                 {
@@ -208,8 +207,8 @@ namespace server.Data.Migrations
                 name: "AspNetUserLogins",
                 columns: table => new
                 {
-                    LoginProvider = table.Column<string>(type: "varchar(128)", maxLength: 128, nullable: false),
-                    ProviderKey = table.Column<string>(type: "varchar(128)", maxLength: 128, nullable: false),
+                    LoginProvider = table.Column<string>(type: "varchar(255)", nullable: false),
+                    ProviderKey = table.Column<string>(type: "varchar(255)", nullable: false),
                     ProviderDisplayName = table.Column<string>(type: "longtext", nullable: true),
                     UserId = table.Column<string>(type: "varchar(255)", nullable: false)
                 },
@@ -255,8 +254,8 @@ namespace server.Data.Migrations
                 columns: table => new
                 {
                     UserId = table.Column<string>(type: "varchar(255)", nullable: false),
-                    LoginProvider = table.Column<string>(type: "varchar(128)", maxLength: 128, nullable: false),
-                    Name = table.Column<string>(type: "varchar(128)", maxLength: 128, nullable: false),
+                    LoginProvider = table.Column<string>(type: "varchar(255)", nullable: false),
+                    Name = table.Column<string>(type: "varchar(255)", nullable: false),
                     Value = table.Column<string>(type: "longtext", nullable: true)
                 },
                 constraints: table =>
@@ -266,6 +265,27 @@ namespace server.Data.Migrations
                         name: "FK_AspNetUserTokens_AspNetUsers_UserId",
                         column: x => x.UserId,
                         principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                })
+                .Annotation("MySQL:Charset", "utf8mb4");
+
+            migrationBuilder.CreateTable(
+                name: "RecipeImage",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("MySQL:ValueGenerationStrategy", MySQLValueGenerationStrategy.IdentityColumn),
+                    ImageData = table.Column<byte[]>(type: "mediumblob", nullable: false),
+                    RecipeId = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_RecipeImage", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_RecipeImage_Recipe_RecipeId",
+                        column: x => x.RecipeId,
+                        principalTable: "Recipe",
                         principalColumn: "Id",
                         onDelete: ReferentialAction.Cascade);
                 })
@@ -349,6 +369,11 @@ namespace server.Data.Migrations
                 name: "IX_PersistedGrants_SubjectId_SessionId_Type",
                 table: "PersistedGrants",
                 columns: new[] { "SubjectId", "SessionId", "Type" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RecipeImage_RecipeId",
+                table: "RecipeImage",
+                column: "RecipeId");
         }
 
         /// <inheritdoc />
@@ -382,13 +407,16 @@ namespace server.Data.Migrations
                 name: "PersistedGrants");
 
             migrationBuilder.DropTable(
-                name: "Recipe");
+                name: "RecipeImage");
 
             migrationBuilder.DropTable(
                 name: "AspNetRoles");
 
             migrationBuilder.DropTable(
                 name: "AspNetUsers");
+
+            migrationBuilder.DropTable(
+                name: "Recipe");
         }
     }
 }

--- a/server/Data/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/server/Data/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -235,12 +235,10 @@ namespace server.Data.Migrations
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserLogin<string>", b =>
                 {
                     b.Property<string>("LoginProvider")
-                        .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("varchar(255)");
 
                     b.Property<string>("ProviderKey")
-                        .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("varchar(255)");
 
                     b.Property<string>("ProviderDisplayName")
                         .HasColumnType("longtext");
@@ -277,12 +275,10 @@ namespace server.Data.Migrations
                         .HasColumnType("varchar(255)");
 
                     b.Property<string>("LoginProvider")
-                        .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("varchar(255)");
 
                     b.Property<string>("Name")
-                        .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("varchar(255)");
 
                     b.Property<string>("Value")
                         .HasColumnType("longtext");
@@ -384,7 +380,8 @@ namespace server.Data.Migrations
                         .HasColumnType("smallint");
 
                     b.Property<string>("Categories")
-                        .HasColumnType("tinytext");
+                        .IsRequired()
+                        .HasColumnType("text");
 
                     b.Property<string>("CookTime")
                         .HasColumnType("tinytext");
@@ -400,13 +397,11 @@ namespace server.Data.Migrations
                         .HasColumnType("text");
 
                     b.Property<string>("DietaryRestrictions")
+                        .IsRequired()
                         .HasColumnType("text");
 
                     b.Property<string>("Directions")
                         .IsRequired()
-                        .HasColumnType("text");
-
-                    b.Property<string>("Image")
                         .HasColumnType("text");
 
                     b.Property<string>("Ingredients")
@@ -437,6 +432,26 @@ namespace server.Data.Migrations
 
                             t.HasCheckConstraint("CK_Recipe_DateUpdated", "DateUpdated >= DateCreated");
                         });
+                });
+
+            modelBuilder.Entity("server.Models.RecipeImage", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("int");
+
+                    b.Property<byte[]>("ImageData")
+                        .IsRequired()
+                        .HasColumnType("mediumblob");
+
+                    b.Property<int>("RecipeId")
+                        .HasColumnType("int");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("RecipeId");
+
+                    b.ToTable("RecipeImage");
                 });
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRoleClaim<string>", b =>
@@ -488,6 +503,22 @@ namespace server.Data.Migrations
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
+                });
+
+            modelBuilder.Entity("server.Models.RecipeImage", b =>
+                {
+                    b.HasOne("server.Models.Recipe", "Recipe")
+                        .WithMany("Images")
+                        .HasForeignKey("RecipeId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Recipe");
+                });
+
+            modelBuilder.Entity("server.Models.Recipe", b =>
+                {
+                    b.Navigation("Images");
                 });
 #pragma warning restore 612, 618
         }

--- a/server/Enums/DietaryRestriction.cs
+++ b/server/Enums/DietaryRestriction.cs
@@ -1,0 +1,53 @@
+namespace server.Enums
+{
+  /// <summary>
+  /// Dietary restriction for a recipe.
+  /// </summary>
+  public enum DietaryRestriction
+  {
+    /// <summary>
+    /// No dietary restriction.
+    /// </summary>
+    None,
+
+    /// <summary>
+    /// Vegan.
+    /// </summary>
+    Vegan,
+
+    /// <summary>
+    /// Vegetarian.
+    /// </summary>
+    Vegetarian,
+
+    /// <summary>
+    /// Pescatarian.
+    /// </summary>
+    Pescatarian,
+
+    /// <summary>
+    /// Gluten-free.
+    /// </summary>
+    GlutenFree,
+
+    /// <summary>
+    /// Dairy-free.
+    /// </summary>
+    DairyFree,
+
+    /// <summary>
+    /// Nut-free.
+    /// </summary>
+    NutFree,
+
+    /// <summary>
+    /// Kosher.
+    /// </summary>
+    Kosher,
+
+    /// <summary>
+    /// Halal.
+    /// </summary>
+    Halal
+  }
+}

--- a/server/Enums/RecipeCategory.cs
+++ b/server/Enums/RecipeCategory.cs
@@ -1,0 +1,73 @@
+namespace server.Enums
+{
+  /// <summary>
+  /// Category for a recipe.
+  /// </summary>
+  public enum RecipeCategory
+  {
+    /// <summary>
+    /// No category.
+    /// </summary>
+    None,
+
+    /// <summary>
+    /// Appetizer.
+    /// </summary>
+    Appetizer,
+
+    /// <summary>
+    /// Main course.
+    /// </summary>
+    MainCourse,
+
+    /// <summary>
+    /// Dessert.
+    /// </summary>
+    Dessert,
+
+    /// <summary>
+    /// Beverage.
+    /// </summary>
+    Beverage,
+
+    /// <summary>
+    /// Salad.
+    /// </summary>
+    Salad,
+
+    /// <summary>
+    /// Soup.
+    /// </summary>
+    Soup,
+
+    /// <summary>
+    /// Side dish.
+    /// </summary>
+    SideDish,
+
+    /// <summary>
+    /// Snack.
+    /// </summary>
+    Breakfast,
+
+    /// <summary>
+    /// Brunch.
+    /// </summary>
+    Brunch,
+
+    /// <summary>
+    /// Lunch.
+    /// </summary>
+    Lunch,
+
+    /// <summary>
+    /// Dinner.
+    /// </summary>
+    Dinner,
+
+    /// <summary>
+    /// Snack.
+    /// </summary>
+    Snack
+  }
+}

--- a/server/Models/Ingredient.cs
+++ b/server/Models/Ingredient.cs
@@ -1,12 +1,23 @@
+using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
 namespace server.Models
 {
+  /// <summary>
+  /// An ingredient.
+  /// </summary>
   public class Ingredient
   {
+    /// <summary>
+    /// The ingredient ID.
+    /// </summary>
+    [Key]
     [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
     public required int Id { get; set; }
 
+    /// <summary>
+    /// The name of the ingredient.
+    /// </summary>
     [Column(TypeName = "varchar(64)")]
     public required string Name { get; set; }
   }

--- a/server/Models/RecipeImage.cs
+++ b/server/Models/RecipeImage.cs
@@ -1,0 +1,31 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace server.Models
+{
+  /// <summary>
+  /// An image for a recipe.
+  /// </summary>
+  public class RecipeImage
+  {
+    /// <summary>
+    /// The image ID.
+    /// </summary>
+    [Key]
+    [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+    public required int Id { get; set; }
+
+    /// <summary>
+    /// The image data.
+    /// </summary>
+    [Column(TypeName = "mediumblob")]
+    public required byte[] ImageData { get; set; }
+
+    /// <summary>
+    /// The ID of the recipe this image belongs to.
+    /// </summary>
+    [ForeignKey("Recipe")]
+    public required int RecipeId { get; set; }
+    public required Recipe Recipe { get; set; }
+  }
+}


### PR DESCRIPTION
This pull request adds the recipe category and dietary restriction enums, as well as the RecipeImage table to store images for recipes. It includes the following commits:

- feat: add recipe enum fields

- feat: add RecipeImage table to store images for recipes

- Refactor models

- Add recipe DTO to map to Recipe model

- Recreate initial database schema

- Add api endpoint to get recipe image by id

The changes in this pull request will allow for better categorization and organization of recipes, as well as the ability to associate images with recipes.